### PR TITLE
Reduce unnecessary nesting in example

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -9,27 +9,27 @@ fn main() {
 
     if monitors.is_empty() {
         println!("No external monitors found");
-    } else {
-        for mut monitor in monitors {
-            println!("Monitor");
-            println!("\tDescription: {}", monitor.description());
-            if let Some(desc) = monitor.product_name() {
-                println!("\tProduct Name: {}", desc);
-            }
-            if let Some(number) = monitor.serial_number() {
-                println!("\tSerial Number: {}", number);
-            }
-            if let Ok(input) = monitor.get_vcp_feature(0x60) {
-                println!("\tCurrent input: {:04x}", input.value());
-            }
+        return;
+    }
 
-            if let Some(data) = monitor.edid() {
-                let mut cursor = std::io::Cursor::new(&data);
-                let mut reader = edid_rs::Reader::new(&mut cursor);
-                match edid_rs::EDID::parse(&mut reader) {
-                    Ok(edid) => println!("\tEDID Info: {:?}", edid),
-                    _ => println!("\tCould not parse provided EDID information"),
-                }
+    for mut monitor in monitors {
+        println!("Monitor");
+        println!("\tDescription: {}", monitor.description());
+        if let Some(desc) = monitor.product_name() {
+            println!("\tProduct Name: {}", desc);
+        }
+        if let Some(number) = monitor.serial_number() {
+            println!("\tSerial Number: {}", number);
+        }
+        if let Ok(input) = monitor.get_vcp_feature(0x60) {
+            println!("\tCurrent input: {:04x}", input.value());
+        }
+        if let Some(data) = monitor.edid() {
+            let mut cursor = std::io::Cursor::new(&data);
+            let mut reader = edid_rs::Reader::new(&mut cursor);
+            match edid_rs::EDID::parse(&mut reader) {
+                Ok(edid) => println!("\tEDID Info: {:?}", edid),
+                _ => println!("\tCould not parse provided EDID information"),
             }
         }
     }


### PR DESCRIPTION
Thanks for making this library available and for the work that went into it. It serves as a dependency for a higher-level API crate that I’ve started using in a small project.

This PR makes a minor change to the provided example, reducing unnecessary nesting.

It removes the wrapping of the main logic in an else block by adding an early return for the error condition.

The change should align with common best practices for error handling and aligning the "happy path" on the left for improved readability.