### PR TITLE
Use map_or instead of map followed by unwrap_or

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -166,8 +166,7 @@ impl Monitor {
             .find(&display_serial_key)
             .and_then(|x| x.downcast::<CFNumber>())
             .and_then(|x| x.to_i32())
-            .map(|x| x as u32)
-            .unwrap_or(0);
+            .map_or(0, |x| x as u32);
 
         if display_vendor == display.vendor_number()
             && display_product == display.model_number()


### PR DESCRIPTION
A minor change making things more concise. 