### PR TITLE
Support for Apple Silicon Macs (M1/M2/M3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+rust-toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["hardware-support", "os::macos-apis"]
 edition = "2021"
 
 [dependencies]
-core-foundation = "0.10.0"
-core-foundation-sys = "0.8"
-core-graphics = "0.24"
-ddc = "0.3"
+core-foundation = "0.10"
+core-foundation-sys = "^0.8"
+core-graphics = "^0.24"
+ddc = "0.2"
 io-kit-sys = "0.4"
 mach = "0.3"
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ddc-macos"
-version = "0.3.0"
+version = "0.2.2"
 authors = ["Haim Gelfenbeyn <haim@g8n.me>"]
 description = "DDC/CI monitor control on MacOS"
 documentation = "https://haimgel.github.io/ddc-macos-rs/ddc_macos"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ edition = "2021"
 
 [dependencies]
 core-foundation = "0.10"
-core-foundation-sys = "^0.8"
-core-graphics = "^0.24"
+core-foundation-sys = "0.8"
+core-graphics = "0.24"
+# ddc must stay on "0.2" till ddc-hi is also updated
 ddc = "0.2"
 io-kit-sys = "0.4"
-mach = "0.3"
-thiserror = "1"
+mach2 = "0.4"
+thiserror = "1.0"
 
 [dev-dependencies]
 edid-rs = "0.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 max_width = 120
-edition = "2021"
+style_edition = "2021"
 use_try_shorthand = true

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -63,16 +63,17 @@ pub fn get_display_av_service(display: CGDisplay) -> Result<IOAVService, Error> 
                 while let Some(service) = iter.next() {
                     if get_service_registry_entry_name(service.as_raw())? == "DCPAVServiceProxy" {
                         let av_service = unsafe { IOAVServiceCreateWithService(kCFAllocatorDefault, service.as_raw()) };
-                        let loc_ref = unsafe {
-                            CFType::wrap_under_create_rule(IORegistryEntryCreateCFProperty(
-                                service.as_raw(),
-                                CFString::from_static_string("Location").as_concrete_TypeRef(),
-                                kCFAllocatorDefault,
-                                kIORegistryIterateRecursively,
-                            ))
-                        };
-                        if !av_service.is_null() && loc_ref == external_location {
-                            return Ok(av_service);
+                        let loc_ref = unsafe { IORegistryEntryCreateCFProperty(
+                            service.as_raw(),
+                            CFString::from_static_string("Location").as_concrete_TypeRef(),
+                            kCFAllocatorDefault,
+                            kIORegistryIterateRecursively,
+                        ) };
+                        if !loc_ref.is_null() {
+                            let loc_ref = unsafe { CFType::wrap_under_create_rule(loc_ref) };
+                            if !av_service.is_null() && (loc_ref == external_location) {
+                                return Ok(av_service);
+                            }
                         }
                     }
                 }

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -1,0 +1,99 @@
+use crate::error::Error;
+use crate::error::Error::{DisplayLocationNotFound, ServiceNotFound};
+use crate::iokit::CoreDisplay_DisplayCreateInfoDictionary;
+use crate::iokit::IoIterator;
+use crate::kern_try;
+use core_foundation::base::{CFType, TCFType};
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::string::CFString;
+use core_foundation_sys::base::{kCFAllocatorDefault, CFAllocatorRef, CFTypeRef, OSStatus};
+use core_graphics::display::CGDisplay;
+use io_kit_sys::keys::kIOServicePlane;
+use io_kit_sys::types::{io_object_t, io_registry_entry_t};
+use io_kit_sys::{
+    kIORegistryIterateRecursively, IORegistryEntryCreateCFProperty, IORegistryEntryGetName, IORegistryEntryGetPath,
+};
+use std::ffi::CStr;
+use std::os::raw::{c_uint, c_void};
+
+pub type IOAVService = CFTypeRef;
+
+#[link(name = "CoreDisplay", kind = "framework")]
+extern "C" {
+    // Creates an IOAVService from an existing I/O Kit service
+    pub fn IOAVServiceCreateWithService(allocator: CFAllocatorRef, service: io_object_t) -> IOAVService;
+
+    // Reads data over I2C from the specified IOAVService
+    pub fn IOAVServiceReadI2C(
+        service: IOAVService,
+        chip_address: c_uint,
+        offset: c_uint,
+        output_buffer: *mut c_void,
+        output_buffer_size: c_uint,
+    ) -> OSStatus;
+
+    // Writes data over I2C to the specified IOAVService
+    pub fn IOAVServiceWriteI2C(
+        service: IOAVService,
+        chip_address: c_uint,
+        data_address: c_uint,
+        input_buffer: *const c_void,
+        input_buffer_size: c_uint,
+    ) -> OSStatus;
+}
+
+pub fn get_display_av_service(display: CGDisplay) -> Result<IOAVService, Error> {
+    if display.is_builtin() {
+        return Err(ServiceNotFound);
+    }
+    let display_infos: CFDictionary<CFString, CFType> =
+        unsafe { CFDictionary::wrap_under_create_rule(CoreDisplay_DisplayCreateInfoDictionary(display.id)) };
+    let location = display_infos
+        .find(CFString::from_static_string("IODisplayLocation"))
+        .ok_or(DisplayLocationNotFound)?
+        .downcast::<CFString>()
+        .ok_or(DisplayLocationNotFound)?
+        .to_string();
+    let external_location = CFString::from_static_string("External").into_CFType();
+
+    let mut iter = IoIterator::root()?;
+    while let Some(service) = iter.next() {
+        if let Ok(registry_location) = get_service_registry_entry_path(service.as_raw()) {
+            if registry_location == location {
+                while let Some(service) = iter.next() {
+                    if get_service_registry_entry_name(service.as_raw())? == "DCPAVServiceProxy" {
+                        let av_service = unsafe { IOAVServiceCreateWithService(kCFAllocatorDefault, service.as_raw()) };
+                        let loc_ref = unsafe {
+                            CFType::wrap_under_create_rule(IORegistryEntryCreateCFProperty(
+                                service.as_raw(),
+                                CFString::from_static_string("Location").as_concrete_TypeRef(),
+                                kCFAllocatorDefault,
+                                kIORegistryIterateRecursively,
+                            ))
+                        };
+                        if !av_service.is_null() && loc_ref == external_location {
+                            return Ok(av_service);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Err(ServiceNotFound)
+}
+
+fn get_service_registry_entry_path(entry: io_registry_entry_t) -> Result<String, Error> {
+    let mut path_buffer = [0_i8; 1024];
+    unsafe {
+        kern_try!(IORegistryEntryGetPath(entry, kIOServicePlane, path_buffer.as_mut_ptr()));
+        Ok(CStr::from_ptr(path_buffer.as_ptr()).to_string_lossy().into_owned())
+    }
+}
+
+fn get_service_registry_entry_name(entry: io_registry_entry_t) -> Result<String, Error> {
+    let mut name = [0; 128];
+    unsafe {
+        kern_try!(IORegistryEntryGetName(entry, name.as_mut_ptr()));
+        Ok(CStr::from_ptr(name.as_ptr()).to_string_lossy().into_owned())
+    }
+}

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -2,13 +2,13 @@ use crate::error::Error;
 use crate::error::Error::{DisplayLocationNotFound, ServiceNotFound};
 use crate::iokit::IoIterator;
 use crate::iokit::{CoreDisplay_DisplayCreateInfoDictionary, IoObject};
-use crate::kern_try;
+use crate::{kern_try, verify_io};
 use core_foundation::base::{CFType, TCFType};
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::CFString;
 use core_foundation_sys::base::{kCFAllocatorDefault, CFAllocatorRef, CFTypeRef, OSStatus};
 use core_graphics::display::CGDisplay;
-use ddc::I2C_ADDRESS_DDC_CI;
+use ddc::{I2C_ADDRESS_DDC_CI, SUB_ADDRESS_DDC_CI};
 use io_kit_sys::keys::kIOServicePlane;
 use io_kit_sys::types::{io_object_t, io_registry_entry_t};
 use io_kit_sys::{
@@ -18,35 +18,46 @@ use io_kit_sys::{
 use mach::kern_return::KERN_SUCCESS;
 use std::ffi::CStr;
 use std::os::raw::{c_uint, c_void};
+use std::time::Duration;
 
 pub type IOAVService = CFTypeRef;
 
-#[link(name = "CoreDisplay", kind = "framework")]
-extern "C" {
-    // Creates an IOAVService from an existing I/O Kit service
-    pub fn IOAVServiceCreateWithService(allocator: CFAllocatorRef, service: io_object_t) -> IOAVService;
-
-    // Reads data over I2C from the specified IOAVService
-    pub fn IOAVServiceReadI2C(
-        service: IOAVService,
-        chip_address: c_uint,
-        offset: c_uint,
-        output_buffer: *mut c_void,
-        output_buffer_size: c_uint,
-    ) -> OSStatus;
-
-    // Writes data over I2C to the specified IOAVService
-    pub fn IOAVServiceWriteI2C(
-        service: IOAVService,
-        chip_address: c_uint,
-        data_address: c_uint,
-        input_buffer: *const c_void,
-        input_buffer_size: c_uint,
-    ) -> OSStatus;
+pub(crate) fn execute<'a>(
+    service: &IOAVService,
+    i2c_address: u16,
+    request_data: &[u8],
+    out: &'a mut [u8],
+    response_delay: Duration,
+) -> Result<&'a mut [u8], crate::error::Error> {
+    unsafe {
+        verify_io(IOAVServiceWriteI2C(
+            *service,
+            i2c_address as _, // I2C_ADDRESS_DDC_CI as u32,
+            SUB_ADDRESS_DDC_CI as _,
+            // Skip the first byte, which is the I2C address, which this API does not need
+            request_data[1..].as_ptr() as _,
+            (request_data.len() - 1) as _, // command_length as u32 + 3,
+        ))?;
+    };
+    if !out.is_empty() {
+        std::thread::sleep(response_delay);
+        unsafe {
+            verify_io(IOAVServiceReadI2C(
+                *service,
+                i2c_address as _, // I2C_ADDRESS_DDC_CI as u32,
+                0,
+                out.as_ptr() as _,
+                out.len() as u32,
+            ))?;
+        };
+        Ok(out)
+    } else {
+        Ok(&mut [0u8; 0])
+    }
 }
 
 /// Returns an AVService and its DDC I2C address for a given display
-pub fn get_display_av_service(display: CGDisplay) -> Result<(IOAVService, u16), Error> {
+pub(crate) fn get_display_av_service(display: CGDisplay) -> Result<(IOAVService, u16), Error> {
     if display.is_builtin() {
         return Err(ServiceNotFound);
     }
@@ -137,3 +148,28 @@ fn get_service_registry_entry_name(entry: io_registry_entry_t) -> Result<String,
         Ok(CStr::from_ptr(name.as_ptr()).to_string_lossy().into_owned())
     }
 }
+
+#[link(name = "CoreDisplay", kind = "framework")]
+extern "C" {
+    // Creates an IOAVService from an existing I/O Kit service
+    fn IOAVServiceCreateWithService(allocator: CFAllocatorRef, service: io_object_t) -> IOAVService;
+
+    // Reads data over I2C from the specified IOAVService
+    fn IOAVServiceReadI2C(
+        service: IOAVService,
+        chip_address: c_uint,
+        offset: c_uint,
+        output_buffer: *mut c_void,
+        output_buffer_size: c_uint,
+    ) -> OSStatus;
+
+    // Writes data over I2C to the specified IOAVService
+    fn IOAVServiceWriteI2C(
+        service: IOAVService,
+        chip_address: c_uint,
+        data_address: c_uint,
+        input_buffer: *const c_void,
+        input_buffer_size: c_uint,
+    ) -> OSStatus;
+}
+

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -15,7 +15,7 @@ use io_kit_sys::{
     kIORegistryIterateRecursively, IORegistryEntryCreateCFProperty, IORegistryEntryGetName,
     IORegistryEntryGetParentEntry, IORegistryEntryGetPath,
 };
-use mach::kern_return::KERN_SUCCESS;
+use mach2::kern_return::KERN_SUCCESS;
 use std::ffi::CStr;
 use std::os::raw::{c_uint, c_void};
 use std::time::Duration;

--- a/src/arm.rs
+++ b/src/arm.rs
@@ -73,14 +73,14 @@ pub(crate) fn get_display_av_service(display: CGDisplay) -> Result<(IOAVService,
 
     let mut iter = IoIterator::root()?;
     while let Some(service) = iter.next() {
-        if let Ok(registry_location) = get_service_registry_entry_path(service.as_raw()) {
+        if let Ok(registry_location) = get_service_registry_entry_path((&service).into()) {
             if registry_location == location {
                 while let Some(service) = iter.next() {
-                    if get_service_registry_entry_name(service.as_raw())? == "DCPAVServiceProxy" {
-                        let av_service = unsafe { IOAVServiceCreateWithService(kCFAllocatorDefault, service.as_raw()) };
+                    if get_service_registry_entry_name((&service).into())? == "DCPAVServiceProxy" {
+                        let av_service = unsafe { IOAVServiceCreateWithService(kCFAllocatorDefault, (&service).into()) };
                         let loc_ref = unsafe {
                             IORegistryEntryCreateCFProperty(
-                                service.as_raw(),
+                                (&service).into(),
                                 CFString::from_static_string("Location").as_concrete_TypeRef(),
                                 kCFAllocatorDefault,
                                 kIORegistryIterateRecursively,
@@ -109,7 +109,7 @@ fn i2c_address(service: IoObject) -> u16 {
     // not a standard 0x37 but 0xB7.
     let mut parent: io_registry_entry_t = 0;
     unsafe {
-        if IORegistryEntryGetParentEntry(service.as_raw(), kIOServicePlane, &mut parent) != KERN_SUCCESS {
+        if IORegistryEntryGetParentEntry((&service).into(), kIOServicePlane, &mut parent) != KERN_SUCCESS {
             return I2C_ADDRESS_DDC_CI;
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use core_graphics::base::CGError;
 use ddc::ErrorCode;
 use io_kit_sys::ret::kIOReturnSuccess;
-use mach::kern_return::{kern_return_t, KERN_FAILURE};
+use mach2::kern_return::{kern_return_t, KERN_FAILURE};
 use thiserror::Error;
 
 /// An error that can occur during DDC/CI communication with a monitor
@@ -20,7 +20,7 @@ pub enum Error {
     #[error("Service not found")]
     ServiceNotFound,
     /// Display location not found
-    #[error("Service not found")]
+    #[error("Display location not found")]
     DisplayLocationNotFound,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,51 @@
+use core_graphics::base::CGError;
+use ddc::ErrorCode;
+use io_kit_sys::ret::kIOReturnSuccess;
+use mach::kern_return::{kern_return_t, KERN_FAILURE};
+use thiserror::Error;
+
+/// An error that can occur during DDC/CI communication with a monitor
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Core Graphics errors
+    #[error("Core Graphics error: {0}")]
+    CoreGraphics(CGError),
+    /// Kernel I/O errors
+    #[error("MacOS kernel I/O error: {0}")]
+    Io(kern_return_t),
+    /// DDC/CI errors
+    #[error("DDC/CI error: {0}")]
+    Ddc(ErrorCode),
+    /// Service not found
+    #[error("Service not found")]
+    ServiceNotFound,
+    /// Display location not found
+    #[error("Service not found")]
+    DisplayLocationNotFound,
+}
+
+pub fn verify_io(result: kern_return_t) -> Result<(), Error> {
+    if result == kIOReturnSuccess {
+        Ok(())
+    } else {
+        Err(Error::Io(result))
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Error::Io(error.raw_os_error().unwrap_or(KERN_FAILURE))
+    }
+}
+
+impl From<ErrorCode> for Error {
+    fn from(error: ErrorCode) -> Self {
+        Error::Ddc(error)
+    }
+}
+
+impl From<CGError> for Error {
+    fn from(error: CGError) -> Self {
+        Error::CoreGraphics(error)
+    }
+}

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -1,8 +1,8 @@
 use crate::error::{verify_io, Error};
 use crate::iokit::{kIODisplayOnlyPreferredName, IODisplayCreateInfoDictionary};
 use crate::iokit::{
-    kIOI2CDDCciReplyTransactionType, kIOI2CNoTransactionType, kIOI2CSimpleTransactionType, IOFBCopyI2CInterfaceForBus,
-    IOFBGetI2CInterfaceCount, IOI2CRequest, IoI2CInterfaceConnection,
+    kIOI2CDDCciReplyTransactionType, kIOI2CSimpleTransactionType, IOFBCopyI2CInterfaceForBus, IOFBGetI2CInterfaceCount,
+    IOI2CRequest, IoI2CInterfaceConnection,
 };
 use crate::iokit::{IoIterator, IoObject};
 use core_foundation::base::{CFType, TCFType};
@@ -11,7 +11,6 @@ use core_foundation::number::CFNumber;
 use core_foundation::string::CFString;
 use core_foundation_sys::base::kCFAllocatorDefault;
 use core_graphics::display::CGDisplay;
-use ddc::{Command, CommandResult};
 use io_kit_sys::ret::kIOReturnSuccess;
 use io_kit_sys::types::{io_service_t, IOItemCount};
 use io_kit_sys::IORegistryEntryCreateCFProperties;
@@ -100,7 +99,7 @@ pub fn get_io_framebuffer_port(display: CGDisplay) -> Option<IoObject> {
 pub(crate) unsafe fn send_request(
     service: &IoObject,
     request: &mut IOI2CRequest,
-    post_request_delay: u32,
+    // post_request_delay: u32,
 ) -> Result<(), Error> {
     let mut bus_count = 0;
     let mut result: Result<(), Error> = Err(Error::Io(KERN_FAILURE));
@@ -117,14 +116,6 @@ pub(crate) unsafe fn send_request(
             }
         }
     }
-    std::thread::sleep(std::time::Duration::from_millis(post_request_delay as u64));
+    // std::thread::sleep(std::time::Duration::from_millis(post_request_delay as u64));
     result
-}
-
-pub(crate) fn get_response_transaction_type<C: Command>() -> u32 {
-    if C::Ok::MAX_LEN == 0 {
-        kIOI2CNoTransactionType
-    } else {
-        unsafe { get_supported_transaction_type().unwrap_or(kIOI2CNoTransactionType) }
-    }
 }

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -15,7 +15,7 @@ use ddc::SUB_ADDRESS_DDC_CI;
 use io_kit_sys::ret::kIOReturnSuccess;
 use io_kit_sys::types::{io_service_t, IOItemCount};
 use io_kit_sys::IORegistryEntryCreateCFProperties;
-use mach::kern_return::KERN_FAILURE;
+use mach2::kern_return::KERN_FAILURE;
 use std::time::Duration;
 
 pub(crate) fn execute<'a>(

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -1,0 +1,130 @@
+use crate::error::{verify_io, Error};
+use crate::iokit::{kIODisplayOnlyPreferredName, IODisplayCreateInfoDictionary};
+use crate::iokit::{
+    kIOI2CDDCciReplyTransactionType, kIOI2CNoTransactionType, kIOI2CSimpleTransactionType, IOFBCopyI2CInterfaceForBus,
+    IOFBGetI2CInterfaceCount, IOI2CRequest, IoI2CInterfaceConnection,
+};
+use crate::iokit::{IoIterator, IoObject};
+use core_foundation::base::{CFType, TCFType};
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::number::CFNumber;
+use core_foundation::string::CFString;
+use core_foundation_sys::base::kCFAllocatorDefault;
+use core_graphics::display::CGDisplay;
+use ddc::{Command, CommandResult};
+use io_kit_sys::ret::kIOReturnSuccess;
+use io_kit_sys::types::{io_service_t, IOItemCount};
+use io_kit_sys::IORegistryEntryCreateCFProperties;
+use mach::kern_return::KERN_FAILURE;
+
+pub fn display_info_dict(frame_buffer: &IoObject) -> Option<CFDictionary<CFString, CFType>> {
+    unsafe {
+        let info = IODisplayCreateInfoDictionary(frame_buffer.into(), kIODisplayOnlyPreferredName).as_ref()?;
+        Some(CFDictionary::<CFString, CFType>::wrap_under_create_rule(info))
+    }
+}
+
+/// Get supported I2C / DDC transaction types
+/// DDCciReply is what we want, but Simple will also work
+pub unsafe fn get_supported_transaction_type() -> Option<u32> {
+    let transaction_types_key = CFString::from_static_string("IOI2CTransactionTypes");
+
+    for io_service in IoIterator::for_service_names("IOFramebufferI2CInterface")? {
+        let mut service_properties = std::ptr::null_mut();
+        if IORegistryEntryCreateCFProperties(
+            (&io_service).into(),
+            &mut service_properties,
+            kCFAllocatorDefault as _,
+            0,
+        ) == kIOReturnSuccess
+        {
+            let info = CFDictionary::<CFString, CFType>::wrap_under_create_rule(service_properties as _);
+            let transaction_types = info.find(&transaction_types_key)?.downcast::<CFNumber>()?.to_i64()?;
+            if ((1 << kIOI2CDDCciReplyTransactionType) & transaction_types) != 0 {
+                return Some(kIOI2CDDCciReplyTransactionType);
+            } else if ((1 << kIOI2CSimpleTransactionType) & transaction_types) != 0 {
+                return Some(kIOI2CSimpleTransactionType);
+            }
+        }
+    }
+    None
+}
+
+/// Finds if a framebuffer that matches display
+fn framebuffer_port_matches_display(port: &IoObject, display: CGDisplay) -> Option<()> {
+    let mut bus_count: IOItemCount = 0;
+    unsafe {
+        IOFBGetI2CInterfaceCount(port.into(), &mut bus_count);
+    }
+    if bus_count == 0 {
+        return None;
+    };
+
+    let info = display_info_dict(port)?;
+
+    let display_vendor_key = CFString::from_static_string("DisplayVendorID");
+    let display_product_key = CFString::from_static_string("DisplayProductID");
+    let display_serial_key = CFString::from_static_string("DisplaySerialNumber");
+
+    let display_vendor = info.find(&display_vendor_key)?.downcast::<CFNumber>()?.to_i64()? as u32;
+    let display_product = info.find(&display_product_key)?.downcast::<CFNumber>()?.to_i64()? as u32;
+    // Display serial number is not always present. If it's not there, default to zero
+    // (to match what CGDisplay.serial_number() returns
+    let display_serial = info
+        .find(&display_serial_key)
+        .and_then(|x| x.downcast::<CFNumber>())
+        .and_then(|x| x.to_i32())
+        .map(|x| x as u32)
+        .unwrap_or(0);
+
+    if display_vendor == display.vendor_number()
+        && display_product == display.model_number()
+        && display_serial == display.serial_number()
+    {
+        Some(())
+    } else {
+        None
+    }
+}
+
+/// Gets the framebuffer port for a display
+pub fn get_io_framebuffer_port(display: CGDisplay) -> Option<IoObject> {
+    if display.is_builtin() {
+        return None;
+    }
+    IoIterator::for_services("IOFramebuffer")?
+        .find(|framebuffer| framebuffer_port_matches_display(framebuffer, display).is_some())
+}
+
+/// send an I2C request to a display
+pub(crate) unsafe fn send_request(
+    service: &IoObject,
+    request: &mut IOI2CRequest,
+    post_request_delay: u32,
+) -> Result<(), Error> {
+    let mut bus_count = 0;
+    let mut result: Result<(), Error> = Err(Error::Io(KERN_FAILURE));
+    verify_io(IOFBGetI2CInterfaceCount(service.into(), &mut bus_count))?;
+    for bus in 0..bus_count {
+        let mut interface: io_service_t = 0;
+        if IOFBCopyI2CInterfaceForBus(service.into(), bus, &mut interface) == kIOReturnSuccess {
+            let interface = IoObject::from(interface);
+            result = IoI2CInterfaceConnection::new(&interface)
+                .and_then(|connection| connection.send_request(request))
+                .map_err(From::from);
+            if result.is_ok() {
+                break;
+            }
+        }
+    }
+    std::thread::sleep(std::time::Duration::from_millis(post_request_delay as u64));
+    result
+}
+
+pub(crate) fn get_response_transaction_type<C: Command>() -> u32 {
+    if C::Ok::MAX_LEN == 0 {
+        kIOI2CNoTransactionType
+    } else {
+        unsafe { get_supported_transaction_type().unwrap_or(kIOI2CNoTransactionType) }
+    }
+}

--- a/src/intel.rs
+++ b/src/intel.rs
@@ -1,5 +1,5 @@
 use crate::error::{verify_io, Error};
-use crate::iokit::{kIODisplayOnlyPreferredName, IODisplayCreateInfoDictionary};
+use crate::iokit::{kIODisplayOnlyPreferredName, kIOI2CNoTransactionType, IODisplayCreateInfoDictionary};
 use crate::iokit::{
     kIOI2CDDCciReplyTransactionType, kIOI2CSimpleTransactionType, IOFBCopyI2CInterfaceForBus, IOFBGetI2CInterfaceCount,
     IOI2CRequest, IoI2CInterfaceConnection,
@@ -11,12 +11,52 @@ use core_foundation::number::CFNumber;
 use core_foundation::string::CFString;
 use core_foundation_sys::base::kCFAllocatorDefault;
 use core_graphics::display::CGDisplay;
+use ddc::SUB_ADDRESS_DDC_CI;
 use io_kit_sys::ret::kIOReturnSuccess;
 use io_kit_sys::types::{io_service_t, IOItemCount};
 use io_kit_sys::IORegistryEntryCreateCFProperties;
 use mach::kern_return::KERN_FAILURE;
+use std::time::Duration;
 
-pub fn display_info_dict(frame_buffer: &IoObject) -> Option<CFDictionary<CFString, CFType>> {
+pub(crate) fn execute<'a>(
+    service: &IoObject,
+    i2c_address: u16,
+    request_data: &[u8],
+    out: &'a mut [u8],
+    response_delay: Duration,
+) -> Result<&'a mut [u8], crate::error::Error> {
+    let mut request: IOI2CRequest = unsafe { std::mem::zeroed() };
+
+    request.commFlags = 0;
+    request.sendAddress = (i2c_address << 1) as u32;
+    request.sendTransactionType = kIOI2CSimpleTransactionType;
+    request.sendBuffer = &request_data as *const _ as usize;
+    request.sendBytes = request_data.len() as u32;
+    request.minReplyDelay = response_delay.as_nanos() as u64;
+    request.result = -1;
+
+    request.replyTransactionType = if out.is_empty() {
+        kIOI2CNoTransactionType
+    } else {
+        unsafe { get_supported_transaction_type().unwrap_or(kIOI2CNoTransactionType) }
+    };
+    request.replyAddress = ((i2c_address << 1) | 1) as u32;
+    request.replySubAddress = SUB_ADDRESS_DDC_CI;
+
+    request.replyBuffer = &out as *const _ as usize;
+    request.replyBytes = out.len() as u32;
+
+    unsafe {
+        send_request(service, &mut request)?;
+    }
+    if request.replyTransactionType != kIOI2CNoTransactionType {
+        Ok(&mut [0u8; 0])
+    } else {
+        Ok(out)
+    }
+}
+
+fn display_info_dict(frame_buffer: &IoObject) -> Option<CFDictionary<CFString, CFType>> {
     unsafe {
         let info = IODisplayCreateInfoDictionary(frame_buffer.into(), kIODisplayOnlyPreferredName).as_ref()?;
         Some(CFDictionary::<CFString, CFType>::wrap_under_create_rule(info))
@@ -25,7 +65,7 @@ pub fn display_info_dict(frame_buffer: &IoObject) -> Option<CFDictionary<CFStrin
 
 /// Get supported I2C / DDC transaction types
 /// DDCciReply is what we want, but Simple will also work
-pub unsafe fn get_supported_transaction_type() -> Option<u32> {
+unsafe fn get_supported_transaction_type() -> Option<u32> {
     let transaction_types_key = CFString::from_static_string("IOI2CTransactionTypes");
 
     for io_service in IoIterator::for_service_names("IOFramebufferI2CInterface")? {
@@ -87,7 +127,7 @@ fn framebuffer_port_matches_display(port: &IoObject, display: CGDisplay) -> Opti
 }
 
 /// Gets the framebuffer port for a display
-pub fn get_io_framebuffer_port(display: CGDisplay) -> Option<IoObject> {
+pub(crate) fn get_io_framebuffer_port(display: CGDisplay) -> Option<IoObject> {
     if display.is_builtin() {
         return None;
     }
@@ -96,7 +136,7 @@ pub fn get_io_framebuffer_port(display: CGDisplay) -> Option<IoObject> {
 }
 
 /// send an I2C request to a display
-pub(crate) unsafe fn send_request(
+unsafe fn send_request(
     service: &IoObject,
     request: &mut IOI2CRequest,
     // post_request_delay: u32,
@@ -116,6 +156,5 @@ pub(crate) unsafe fn send_request(
             }
         }
     }
-    // std::thread::sleep(std::time::Duration::from_millis(post_request_delay as u64));
     result
 }

--- a/src/iokit/display.rs
+++ b/src/iokit/display.rs
@@ -4,7 +4,7 @@
 use core_foundation::dictionary::CFDictionaryRef;
 use core_graphics::display::CGDirectDisplayID;
 use io_kit_sys::types::{io_service_t, IOOptionBits};
-use mach::port::mach_port_t;
+use mach2::port::mach_port_t;
 
 pub const kIODisplayMatchingInfo: IOOptionBits = 0x00000100;
 pub const kIODisplayOnlyPreferredName: IOOptionBits = 0x00000200;

--- a/src/iokit/display.rs
+++ b/src/iokit/display.rs
@@ -2,13 +2,21 @@
 
 /// Selective translation of IOKit/graphics/IOGraphicsLib.h
 use core_foundation::dictionary::CFDictionaryRef;
+use core_graphics::display::CGDirectDisplayID;
 use io_kit_sys::types::{io_service_t, IOOptionBits};
+use mach::port::mach_port_t;
 
 pub const kIODisplayMatchingInfo: IOOptionBits = 0x00000100;
 pub const kIODisplayOnlyPreferredName: IOOptionBits = 0x00000200;
 pub const kIODisplayNoProductName: IOOptionBits = 0x00000400;
 
 extern "C" {
+    // For some reason, this is missing from io_kit_sys
+    pub static kIOMainPortDefault: mach_port_t;
     #[link(name = "IOKit", kind = "framework")]
     pub fn IODisplayCreateInfoDictionary(framebuffer: io_service_t, options: IOOptionBits) -> CFDictionaryRef;
+
+    #[link(name = "CoreDisplay", kind = "framework")]
+    // Creates a display info dictionary for a specified display ID
+    pub fn CoreDisplay_DisplayCreateInfoDictionary(display_id: CGDirectDisplayID) -> CFDictionaryRef;
 }

--- a/src/iokit/errors.rs
+++ b/src/iokit/errors.rs
@@ -1,5 +1,6 @@
 // Copied from https://github.com/svartalf/rust-battery/blob/master/battery/src/platform/darwin/iokit/errors.rs
 
+#[macro_export]
 macro_rules! r#kern_try {
     ($expr:expr) => {
         match $expr {

--- a/src/iokit/errors.rs
+++ b/src/iokit/errors.rs
@@ -4,7 +4,7 @@
 macro_rules! r#kern_try {
     ($expr:expr) => {
         match $expr {
-            mach::kern_return::KERN_SUCCESS => (),
+            mach2::kern_return::KERN_SUCCESS => (),
             err_code => return ::std::result::Result::Err(::std::io::Error::from_raw_os_error(err_code).into()),
         }
     };

--- a/src/iokit/io2c_interface.rs
+++ b/src/iokit/io2c_interface.rs
@@ -2,12 +2,12 @@
 
 /// Translation of IOKit/i2c/IOI2CInterface.h
 extern crate io_kit_sys;
-extern crate mach;
+extern crate mach2;
 
 use crate::iokit::wrappers::IoObject;
 use io_kit_sys::ret::IOReturn;
 use io_kit_sys::types::{io_service_t, IOItemCount, IOOptionBits};
-use mach::vm_types::{mach_vm_address_t, mach_vm_size_t, vm_address_t};
+use mach2::vm_types::{mach_vm_address_t, mach_vm_size_t, vm_address_t};
 use std::os::raw::c_uint;
 
 /// IOI2CRequest.sendTransactionType, IOI2CRequest.replyTransactionType

--- a/src/iokit/mod.rs
+++ b/src/iokit/mod.rs
@@ -1,5 +1,9 @@
 #[macro_use]
 pub(crate) mod errors;
-pub(crate) mod display;
-pub(crate) mod io2c_interface;
-pub(crate) mod wrappers;
+mod display;
+mod io2c_interface;
+mod wrappers;
+
+pub(crate) use display::*;
+pub(crate) use io2c_interface::*;
+pub(crate) use wrappers::*;

--- a/src/iokit/wrappers.rs
+++ b/src/iokit/wrappers.rs
@@ -28,11 +28,6 @@ impl IoObject {
             Ok(CFMutableDictionary::wrap_under_create_rule(props as _).to_immutable())
         }
     }
-
-    /// Accessor method to get the inner `io_object_t`
-    pub fn as_raw(&self) -> io_object_t {
-        self.0
-    }
 }
 
 impl From<io_object_t> for IoObject {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,11 @@
 //! # }
 //! ```
 
+mod arm;
+mod error;
+mod intel;
 mod iokit;
 mod monitor;
 
+pub use error::*;
 pub use monitor::*;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,69 +1,34 @@
 #![deny(missing_docs)]
 
-use crate::iokit::display::*;
-use crate::iokit::io2c_interface::*;
-use crate::iokit::wrappers::*;
-use core_foundation::base::{kCFAllocatorDefault, CFType, TCFType};
+use crate::arm::{IOAVService, IOAVServiceReadI2C, IOAVServiceWriteI2C};
+use crate::error::Error;
+use crate::iokit::CoreDisplay_DisplayCreateInfoDictionary;
+use crate::iokit::IoObject;
+use crate::iokit::*;
+use crate::{arm, intel};
+use core_foundation::base::{CFType, TCFType};
 use core_foundation::data::CFData;
 use core_foundation::dictionary::CFDictionary;
-use core_foundation::number::CFNumber;
 use core_foundation::string::{CFString, CFStringRef};
-use core_graphics::display::{CGDisplay, CGError};
+use core_graphics::display::CGDisplay;
 use ddc::{
     Command, CommandResult, DdcCommand, DdcCommandMarker, DdcHost, ErrorCode, I2C_ADDRESS_DDC_CI, SUB_ADDRESS_DDC_CI,
 };
-use io_kit_sys::ret::kIOReturnSuccess;
-use io_kit_sys::types::{io_service_t, kMillisecondScale, IOItemCount};
-use io_kit_sys::IORegistryEntryCreateCFProperties;
-use mach::kern_return::{kern_return_t, KERN_FAILURE};
+use io_kit_sys::types::kMillisecondScale;
 use std::{fmt, iter};
-use thiserror::Error;
 
-/// An error that can occur during DDC/CI communication with a monitor
-#[derive(Error, Debug)]
-pub enum Error {
-    /// Core Graphics errors
-    #[error("Core Graphics error: {0}")]
-    CoreGraphics(CGError),
-    /// Kernel I/O errors
-    #[error("MacOS kernel I/O error: {0}")]
-    Io(kern_return_t),
-    /// DDC/CI errors
-    #[error("DDC/CI error: {0}")]
-    Ddc(ErrorCode),
-}
-
-fn verify_io(result: kern_return_t) -> Result<(), Error> {
-    if result == kIOReturnSuccess {
-        Ok(())
-    } else {
-        Err(Error::Io(result))
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(error: std::io::Error) -> Self {
-        Error::Io(error.raw_os_error().unwrap_or(KERN_FAILURE))
-    }
-}
-
-impl From<ErrorCode> for Error {
-    fn from(error: ErrorCode) -> Self {
-        Error::Ddc(error)
-    }
-}
-
-impl From<CGError> for Error {
-    fn from(error: CGError) -> Self {
-        Error::CoreGraphics(error)
-    }
+/// DDC access method for a monitor
+#[derive(Debug)]
+enum MonitorService {
+    Intel(IoObject),
+    Arm(IOAVService),
 }
 
 /// A handle to an attached monitor that allows the use of DDC/CI operations.
 #[derive(Debug)]
 pub struct Monitor {
     monitor: CGDisplay,
-    frame_buffer: IoObject,
+    service: MonitorService,
 }
 
 impl fmt::Display for Monitor {
@@ -74,8 +39,8 @@ impl fmt::Display for Monitor {
 
 impl Monitor {
     /// Create a new monitor from the specified handle.
-    fn new(monitor: CGDisplay, frame_buffer: IoObject) -> Self {
-        Monitor { monitor, frame_buffer }
+    fn new(monitor: CGDisplay, service: MonitorService) -> Self {
+        Monitor { monitor, service }
     }
 
     /// Enumerate all connected physical monitors returning [Vec<Monitor>]
@@ -85,8 +50,13 @@ impl Monitor {
             .into_iter()
             .filter_map(|display_id| {
                 let display = CGDisplay::new(display_id);
-                let frame_buffer = Self::get_io_framebuffer_port(display)?;
-                Some(Self::new(display, frame_buffer))
+                return if let Some(service) = intel::get_io_framebuffer_port(display) {
+                    Some(Self::new(display, MonitorService::Intel(service)))
+                } else if let Ok(service) = arm::get_display_av_service(display) {
+                    Some(Self::new(display, MonitorService::Arm(service)))
+                } else {
+                    None
+                };
             })
             .collect();
         Ok(monitors)
@@ -113,7 +83,9 @@ impl Monitor {
 
     /// Product name for this [Monitor], if available
     pub fn product_name(&self) -> Option<String> {
-        let info = Self::display_info_dict(&self.frame_buffer)?;
+        let info: CFDictionary<CFString, CFType> =
+            unsafe { CFDictionary::wrap_under_create_rule(CoreDisplay_DisplayCreateInfoDictionary(self.monitor.id)) };
+
         let display_product_name_key = CFString::from_static_string("DisplayProductName");
         let display_product_names_dict = info.find(&display_product_name_key)?.downcast::<CFDictionary>()?;
         let (_, localized_product_names) = display_product_names_dict.get_keys_and_values();
@@ -124,7 +96,8 @@ impl Monitor {
 
     /// Returns Extended display identification data (EDID) for this [Monitor] as raw bytes data
     pub fn edid(&self) -> Option<Vec<u8>> {
-        let info = Self::display_info_dict(&self.frame_buffer)?;
+        let info: CFDictionary<CFString, CFType> =
+            unsafe { CFDictionary::wrap_under_create_rule(CoreDisplay_DisplayCreateInfoDictionary(self.monitor.id)) };
         let display_product_name_key = CFString::from_static_string("IODisplayEDIDOriginal");
         let edid_data = info.find(&display_product_name_key)?.downcast::<CFData>()?;
         Some(edid_data.bytes().into())
@@ -135,112 +108,113 @@ impl Monitor {
         self.monitor
     }
 
-    fn display_info_dict(frame_buffer: &IoObject) -> Option<CFDictionary<CFString, CFType>> {
-        unsafe {
-            let info = IODisplayCreateInfoDictionary(frame_buffer.into(), kIODisplayOnlyPreferredName).as_ref()?;
-            Some(CFDictionary::<CFString, CFType>::wrap_under_create_rule(info))
-        }
-    }
+    fn execute_intel<C: Command>(&mut self, command: C) -> Result<<C as Command>::Ok, crate::error::Error> {
+        if let MonitorService::Intel(service) = &self.service {
+            let request_data = Self::encode_request(&command)?;
 
-    // Finds a framebuffer that matches display, returns a properly formatted *unique* display name
-    fn framebuffer_port_matches_display(port: &IoObject, display: CGDisplay) -> Option<()> {
-        let mut bus_count: IOItemCount = 0;
-        unsafe {
-            IOFBGetI2CInterfaceCount(port.into(), &mut bus_count);
-        }
-        if bus_count == 0 {
-            return None;
-        };
+            // Allocate data for the response. 36 bytes is larger than any response
+            assert!(C::Ok::MAX_LEN <= 36);
+            let reply_data = [0u8; 36];
+            let mut request: IOI2CRequest = unsafe { std::mem::zeroed() };
 
-        let info = Self::display_info_dict(port)?;
+            request.commFlags = 0;
+            request.sendAddress = (I2C_ADDRESS_DDC_CI << 1) as u32;
+            request.sendTransactionType = kIOI2CSimpleTransactionType;
+            request.sendBuffer = &request_data as *const _ as usize;
+            request.sendBytes = request_data.len() as u32;
+            request.minReplyDelay = C::DELAY_RESPONSE_MS * kMillisecondScale as u64;
+            request.result = -1;
 
-        let display_vendor_key = CFString::from_static_string("DisplayVendorID");
-        let display_product_key = CFString::from_static_string("DisplayProductID");
-        let display_serial_key = CFString::from_static_string("DisplaySerialNumber");
+            request.replyTransactionType = intel::get_response_transaction_type::<C>();
+            request.replyAddress = ((I2C_ADDRESS_DDC_CI << 1) | 1) as u32;
+            request.replySubAddress = SUB_ADDRESS_DDC_CI;
 
-        let display_vendor = info.find(&display_vendor_key)?.downcast::<CFNumber>()?.to_i64()? as u32;
-        let display_product = info.find(&display_product_key)?.downcast::<CFNumber>()?.to_i64()? as u32;
-        // Display serial number is not always present. If it's not there, default to zero
-        // (to match what CGDisplay.serial_number() returns
-        let display_serial = info
-            .find(&display_serial_key)
-            .and_then(|x| x.downcast::<CFNumber>())
-            .and_then(|x| x.to_i32())
-            .map(|x| x as u32)
-            .unwrap_or(0);
+            request.replyBuffer = &reply_data as *const _ as usize;
+            request.replyBytes = reply_data.len() as u32;
 
-        if display_vendor == display.vendor_number()
-            && display_product == display.model_number()
-            && display_serial == display.serial_number()
-        {
-            Some(())
-        } else {
-            None
-        }
-    }
-
-    // Gets the framebuffer port
-    fn get_io_framebuffer_port(display: CGDisplay) -> Option<IoObject> {
-        if display.is_builtin() {
-            return None;
-        }
-        IoIterator::for_services("IOFramebuffer")?
-            .find(|framebuffer| Self::framebuffer_port_matches_display(framebuffer, display).is_some())
-    }
-
-    /// Get supported I2C / DDC transaction types
-    /// DDCciReply is what we want, but Simple will also work
-    unsafe fn get_supported_transaction_type() -> Option<u32> {
-        let transaction_types_key = CFString::from_static_string("IOI2CTransactionTypes");
-
-        for io_service in IoIterator::for_service_names("IOFramebufferI2CInterface")? {
-            let mut service_properties = std::ptr::null_mut();
-            if IORegistryEntryCreateCFProperties(
-                (&io_service).into(),
-                &mut service_properties,
-                kCFAllocatorDefault as _,
-                0,
-            ) == kIOReturnSuccess
-            {
-                let info = CFDictionary::<CFString, CFType>::wrap_under_create_rule(service_properties as _);
-                let transaction_types = info.find(&transaction_types_key)?.downcast::<CFNumber>()?.to_i64()?;
-                if ((1 << kIOI2CDDCciReplyTransactionType) & transaction_types) != 0 {
-                    return Some(kIOI2CDDCciReplyTransactionType);
-                } else if ((1 << kIOI2CSimpleTransactionType) & transaction_types) != 0 {
-                    return Some(kIOI2CSimpleTransactionType);
-                }
+            unsafe {
+                intel::send_request(service, &mut request, C::DELAY_COMMAND_MS as u32)?;
             }
-        }
-        None
-    }
 
-    /// send an I2C request to a display
-    unsafe fn send_request(&self, request: &mut IOI2CRequest, post_request_delay: u32) -> Result<(), Error> {
-        let mut bus_count = 0;
-        let mut result: Result<(), Error> = Err(Error::Io(KERN_FAILURE));
-        verify_io(IOFBGetI2CInterfaceCount((&self.frame_buffer).into(), &mut bus_count))?;
-        for bus in 0..bus_count {
-            let mut interface: io_service_t = 0;
-            if IOFBCopyI2CInterfaceForBus((&self.frame_buffer).into(), bus, &mut interface) == kIOReturnSuccess {
-                let interface = IoObject::from(interface);
-                result = IoI2CInterfaceConnection::new(&interface)
-                    .and_then(|connection| connection.send_request(request))
-                    .map_err(From::from);
-                if result.is_ok() {
-                    break;
-                }
+            if request.replyTransactionType == kIOI2CNoTransactionType {
+                CommandResult::decode(&[0u8; 0]).map_err(From::from)
+            } else {
+                Self::decode_reply::<C>(&reply_data)
             }
+        } else {
+            Err(Error::ServiceNotFound)
         }
-        std::thread::sleep(std::time::Duration::from_millis(post_request_delay as u64));
-        result
     }
 
-    fn get_response_transaction_type<C: Command>(&self, _c: C) -> u32 {
-        if C::Ok::MAX_LEN == 0 {
-            kIOI2CNoTransactionType
+    fn execute_arm<C: Command>(&mut self, command: C) -> Result<<C as Command>::Ok, crate::error::Error> {
+        if let MonitorService::Arm(service) = &self.service {
+            let request_data = Self::encode_request(&command)?;
+            std::thread::sleep(std::time::Duration::from_millis(C::DELAY_COMMAND_MS));
+            let success = unsafe {
+                IOAVServiceWriteI2C(
+                    *service,
+                    I2C_ADDRESS_DDC_CI as u32,
+                    SUB_ADDRESS_DDC_CI as u32,
+                    // Skip the first byte, which is the I2C address, which this API does not need
+                    request_data[1..].as_ptr() as _,
+                    (request_data.len() - 1) as _, // command_length as u32 + 3,
+                )
+            };
+            if success != 0 {
+                return Err(Error::Io(success));
+            }
+            if C::Ok::MAX_LEN == 0 {
+                CommandResult::decode(&[0u8; 0]).map_err(From::from)
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(C::DELAY_RESPONSE_MS));
+                // Allocate data for the response. 36 bytes is larger than any response
+                assert!(C::Ok::MAX_LEN <= 36);
+                let reply_data = [0u8; 36];
+
+                let success = unsafe {
+                    IOAVServiceReadI2C(
+                        *service,
+                        I2C_ADDRESS_DDC_CI as u32,
+                        0,
+                        reply_data.as_ptr() as _,
+                        reply_data.len() as u32,
+                    )
+                };
+                if success != 0 {
+                    return Err(Error::Io(success));
+                }
+                Self::decode_reply::<C>(&reply_data)
+            }
         } else {
-            unsafe { Self::get_supported_transaction_type().unwrap_or(kIOI2CNoTransactionType) }
+            Err(Error::ServiceNotFound)
         }
+    }
+
+    /// Encode the command into request_data buffer
+    fn encode_request<C: Command>(command: &C) -> Result<Vec<u8>, crate::error::Error> {
+        // 36 bytes is an arbitrary number, larger than any I2C command length.
+        // Cannot use [0u8; C::MAX_LEN] (associated constants do not work here)
+        assert!(C::MAX_LEN <= 36);
+        let mut encoded_command = [0u8; 36];
+        let command_length = command.encode(&mut encoded_command)?;
+        let mut request_data = [0u8; 36 + 3];
+        Ok(Self::encode_command(&encoded_command[0..command_length], &mut request_data).to_owned())
+    }
+
+    fn decode_reply<C: Command>(reply_data: &[u8]) -> Result<<C as Command>::Ok, crate::error::Error> {
+        let reply_length = (reply_data[1] & 0x7f) as usize;
+        if reply_length + 2 >= reply_data.len() {
+            return Err(Error::Ddc(ErrorCode::InvalidLength));
+        }
+        let checksum = Self::checksum(
+            iter::once(((I2C_ADDRESS_DDC_CI << 1) | 1) as u8)
+                .chain(iter::once(SUB_ADDRESS_DDC_CI))
+                .chain(reply_data[1..2 + reply_length].iter().cloned()),
+        );
+        if reply_data[2 + reply_length] != checksum {
+            return Err(Error::Ddc(ErrorCode::InvalidChecksum));
+        }
+        CommandResult::decode(&reply_data[2..C::Ok::MAX_LEN + 2]).map_err(From::from)
     }
 }
 
@@ -250,56 +224,9 @@ impl DdcHost for Monitor {
 
 impl DdcCommand for Monitor {
     fn execute<C: Command>(&mut self, command: C) -> Result<<C as Command>::Ok, Self::Error> {
-        // Encode the command into request_data buffer
-        // 36 bytes is an arbitrary number, larger than any I2C command length.
-        // Cannot use [0u8; C::MAX_LEN] (associated constants do not work here)
-        assert!(C::MAX_LEN <= 36);
-        let mut encoded_command = [0u8; 36];
-        let command_length = command.encode(&mut encoded_command)?;
-        let mut request_data = [0u8; 36 + 3];
-        Self::encode_command(&encoded_command[0..command_length], &mut request_data);
-
-        // Allocate data for the response. 36 bytes is larger than any response
-        assert!(C::Ok::MAX_LEN <= 36);
-        let reply_data = [0u8; 36];
-        let mut request: IOI2CRequest = unsafe { std::mem::zeroed() };
-
-        request.commFlags = 0;
-        request.sendAddress = (I2C_ADDRESS_DDC_CI << 1) as u32;
-        request.sendTransactionType = kIOI2CSimpleTransactionType;
-        request.sendBuffer = &request_data as *const _ as usize;
-        request.sendBytes = (command_length + 3) as u32;
-        request.minReplyDelay = C::DELAY_RESPONSE_MS * kMillisecondScale as u64;
-        request.result = -1;
-
-        request.replyTransactionType = self.get_response_transaction_type(command);
-        request.replyAddress = ((I2C_ADDRESS_DDC_CI << 1) | 1) as u32;
-        request.replySubAddress = SUB_ADDRESS_DDC_CI;
-
-        request.replyBuffer = &reply_data as *const _ as usize;
-        request.replyBytes = reply_data.len() as u32;
-
-        unsafe {
-            self.send_request(&mut request, C::DELAY_COMMAND_MS as u32)?;
-        }
-
-        if request.replyTransactionType == kIOI2CNoTransactionType {
-            CommandResult::decode(&[0u8; 0]).map_err(From::from)
-        } else {
-            let reply_length = (reply_data[1] & 0x7f) as usize;
-            if reply_length + 2 >= reply_data.len() {
-                return Err(Error::Ddc(ErrorCode::InvalidLength));
-            }
-
-            let checksum = Self::checksum(
-                iter::once(request.replyAddress as u8)
-                    .chain(iter::once(SUB_ADDRESS_DDC_CI))
-                    .chain(reply_data[1..2 + reply_length].iter().cloned()),
-            );
-            if reply_data[2 + reply_length] != checksum {
-                return Err(Error::Ddc(ErrorCode::InvalidChecksum));
-            }
-            CommandResult::decode(&reply_data[2..reply_length + 2]).map_err(From::from)
+        match &self.service {
+            MonitorService::Intel(_) => self.execute_intel(command),
+            MonitorService::Arm(_) => self.execute_arm(command),
         }
     }
 }


### PR DESCRIPTION
* Refactored Intel and ARM support code into their own sub-modules.
* Switched to `DdcCommandRaw` trait (simpler code with less duplication).
* I tested this on M1 and M3 MacBooks, with DP and HDMI output, and it appears to work fine. 
* Also tested on a 2018 Intel MBP, which continues to work OK, too.
